### PR TITLE
Add range and length checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,20 @@ noSpecial | Check that no special characters are in input
 noAlpha | Check that no normal alphabetical characters are in input
 isForeign | Filter out foreign (new lines, tabs, ctrl keys) characters
 
+### Checks with extra parameters
+The extra parameters for checks should be enclosed in round brackets and be given as an object list - `"parameter": value`. It is important that the key be in double quotes.
+
 #### Adding your own checkers
 Others can easily be added to `$.fn.validator.checks.(newCheck)`. Example of the `noDigits` check
 
 ```javascript
 $.fn.validator.checks.noDigits: function(val, addError) {
-    /\d/.test(val) && addError($.fn.validator.errors.noDigits);
+    if (/\d/.test(val)) {
+        addError($.fn[pluginName].errors.noDigits);
+        return false;
+    }
+
+    return true;
 }
 ```
 
@@ -50,8 +58,10 @@ $.fn.validator.checks.noDigits: function(val, addError) {
 
 `addError` is a callback function used to add the error if the check failed.
 
-#### Calling other checkers in a checker
-You can also call one of the build-in checker or your own as part of any check. Example of the `isText` that does this
+The return status is only used by other check to make sure a condition is met before they run, so it is optional.
+
+#### Calling other checkers in a checker and parameters
+You can also call one of the build-in checkers or your own as part of any check. Example of the `range` check that does this and that also accepts parameters
 
 ```javascript
 $.fn.validator.checks.isText: function(val, addError) {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ isEmail | Checks if input contains a valid email
 noSpecial | Check that no special characters are in input
 noAlpha | Check that no normal alphabetical characters are in input
 isForeign | Filter out foreign (new lines, tabs, ctrl keys) characters
+range(<"min"><,"max">) | Check that input is numbers between a min and/or max range
 
 ### Checks with extra parameters
 The extra parameters for checks should be enclosed in round brackets and be given as an object list - `"parameter": value`. It is important that the key be in double quotes.
@@ -64,13 +65,24 @@ The return status is only used by other check to make sure a condition is met be
 You can also call one of the build-in checkers or your own as part of any check. Example of the `range` check that does this and that also accepts parameters
 
 ```javascript
-$.fn.validator.checks.isText: function(val, addError) {
-    this.noDigits(val, addError);
-    this.noSymbols(val, addError);
-    this.noSpecial(val, addError);
+$.fn.validator.checks.range: function(val, addError, params) {
+    if (this.onlyDigits(val, addError)) {
+        if (params.min !== undefined && val < params.min) {
+            addError($.fn[pluginName].errors.range.min.replace('%d', params.min));
+            return false;
+        }
+        if (params.max !== undefined && val > params.max) {
+            addError($.fn[pluginName].errors.range.max.replace('%d', params.max));
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
 }
 ```
-As you can see each check will just append its own errors to other checks.
+Here it will check that the input is a number (and add the error if it is not), before running the internal checks.
 
 ### Changing/Translating the errors
 The defaults can be overwritten at `$.fn.validator.errors.(error) = 'new error';` before calling the plugin.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ noSpecial | Check that no special characters are in input
 noAlpha | Check that no normal alphabetical characters are in input
 isForeign | Filter out foreign (new lines, tabs, ctrl keys) characters
 range(<"min"><,"max">) | Check that input is numbers between a min and/or max range
+length(<"min"><,"max">) | Check that input is between a min and/or max characters long
 
 ### Checks with extra parameters
 The extra parameters for checks should be enclosed in round brackets and be given as an object list - `"parameter": value`. It is important that the key be in double quotes.

--- a/preview/index.html
+++ b/preview/index.html
@@ -37,6 +37,12 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label class="col-sm-2 control-label" for="range">Numbers range</label>
+                    <div class="col-sm-3">
+                        <input type="text" id="range" class="form-control" placeholder="Between 2-6..." data-check='range("min": 2,"max": 6)'>
+                    </div>
+                </div>
+                <div class="form-group">
                     <label class="col-sm-2 control-label" for="alphas">Alphas only</label>
                     <div class="col-sm-3">
                         <input type="text" id="alphas" class="form-control" placeholder="No symbols..." data-check="noSymbols">

--- a/validation.js
+++ b/validation.js
@@ -315,6 +315,10 @@
         ,noSpecial       : 'No special keys allowed'
         ,noAlpha         : 'No alphabeticals allowed'
         ,noForeign       : 'No foreign characters allowed'
+        ,range           : {
+                            min: 'Value should be %d or more'
+                            ,max: 'Value should be %d or less'
+                           }
     };
     /*
      * Build in checks
@@ -390,6 +394,22 @@
                         }
 
                         return true;
+                    },
+        range       : function(val, addError, params) {
+                        if (this.onlyDigits(val, addError)) {
+                            if (params.min !== undefined && val < params.min) {
+                                addError($.fn[pluginName].errors.range.min.replace('%d', params.min));
+                                return false;
+                            }
+                            if (params.max !== undefined && val > params.max) {
+                                addError($.fn[pluginName].errors.range.max.replace('%d', params.max));
+                                return false;
+                            }
+
+                            return true;
+                        }
+
+                        return false;
                     }
     };
 

--- a/validation.js
+++ b/validation.js
@@ -319,6 +319,10 @@
                             min: 'Value should be %d or more'
                             ,max: 'Value should be %d or less'
                            }
+        ,length           : {
+                            min: 'Value should be %d characters or more'
+                            ,max: 'Value should be %d characters or less'
+                           }
     };
     /*
      * Build in checks
@@ -410,6 +414,18 @@
                         }
 
                         return false;
+                    },
+        length      : function(val, addError, params) {
+                        if (params.min !== undefined && val.length < params.min) {
+                            addError($.fn[pluginName].errors.length.min.replace('%d', params.min));
+                            return false;
+                        }
+                        if (params.max !== undefined && val.length > params.max) {
+                            addError($.fn[pluginName].errors.length.max.replace('%d', params.max));
+                            return false;
+                        }
+
+                        return true;
                     }
     };
 

--- a/validation.js
+++ b/validation.js
@@ -311,36 +311,75 @@
      */
     $.fn[pluginName].checks = {
         noDigits    : function(val, addError) {
-                        /\d/.test(val) && addError($.fn[pluginName].errors.noDigits);
-                      },
+                        if (/\d/.test(val)) {
+                            addError($.fn[pluginName].errors.noDigits);
+                            return false;
+                        }
+
+                        return true;
+                    },
         noSymbols   : function(val, addError) {
                         // See http://unicode-table.com
-                        /[!-/:-@{-~[-`]/.test(val) && addError($.fn[pluginName].errors.noSymbols);
-                      },
+                        if (/[!-/:-@{-~[-`]/.test(val)) {
+                            addError($.fn[pluginName].errors.noSymbols);
+                            return false;
+                        }
+
+                        return true;
+                    },
         isText      : function(val, addError) {
-                        this.noDigits(val, addError);
-                        this.noSymbols(val, addError);
-                        this.noSpecial(val, addError);
-                      },
-        onlyDigits    : function(val, addError) {
-                        /\D/.test(val) && addError($.fn[pluginName].errors.onlyDigits);
-                      },
+                        return (
+                            (this.noDigits(val, addError)
+                            + this.noSymbols(val, addError)
+                            + this.noSpecial(val, addError))
+                            === 3
+                            );
+                    },
+        onlyDigits  : function(val, addError) {
+                        if (/\D/.test(val)) {
+                            addError($.fn[pluginName].errors.onlyDigits);
+                            return false;
+                        }
+
+                        return true;
+                    },
         isEmail     : function(val, addError) {
-                        this.noSpecial(val, addError);
-                        !/^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/.test(val)
-                                && addError($.fn[pluginName].errors.isEmail);
-                      },
-        noSpecial     : function(val, addError) {
+                        if (this.noSpecial(val, addError)) {
+                            if (/^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/.test(val)) {
+                                return true;
+                            } else {
+                                addError($.fn[pluginName].errors.isEmail);
+                            }
+                        }
+
+                        return false;
+                    },
+        noSpecial   : function(val, addError) {
                         // See http://unicode-table.com
-                        /[\u0000-\u001F\u0080-\u009F]/.test(val)
-                                            && addError($.fn[pluginName].errors.noSpecial);
-                      },
-        noAlpha       : function(val, addError) {
-                        /[a-zA-Z]/.test(val) && addError($.fn[pluginName].errors.noAlpha);
-                      },
-        noForeign     : function(val, addError) {
-                        /[\u00C0-\u1FFFF]/.test(val) && addError($.fn[pluginName].errors.noForeign);
-                      }
+                        if (/[\u0000-\u001F\u0080-\u009F]/.test(val)) {
+                            addError($.fn[pluginName].errors.noSpecial);
+                            return false;
+                        }
+
+                        return true;
+                    },
+        noAlpha     : function(val, addError) {
+                        if (/[a-zA-Z]/.test(val)) {
+                            addError($.fn[pluginName].errors.noAlpha);
+
+                            return false;
+                        }
+
+                        return true;
+                    },
+        noForeign   : function(val, addError) {
+                        if (/[\u00C0-\u1FFFF]/.test(val)) {
+                            addError($.fn[pluginName].errors.noForeign);
+                            return false;
+                        }
+
+                        return true;
+                    }
     };
 
     function createInstance(element, options) {

--- a/validation.js
+++ b/validation.js
@@ -142,7 +142,13 @@
                 return;
             }
 
-            var check = this.options.check;
+            var check = this.options.check
+                ,pos = check.indexOf('(') === -1 ? check.length : check.indexOf('(')
+                ,params = check.slice(pos +1, -1);
+
+            check = check.slice(0, pos);
+            params = JSON.parse('{' + params + '}');
+
             // Check function exists before it is enables and that enable is set
             if (typeof $.fn[pluginName].checks[check] === 'function') {
                 this.options.enabledChecker = true;
@@ -158,9 +164,14 @@
 
                     e.stopPropagation();
                     this.errors = '';
-                    // Call the checker with the value
-                    // Also provide a callback to the _addError function setting its this
-                    $.fn[pluginName].checks[check]($e.val(), this._addError.bind(this));
+
+                    // Do not call checker on empty values
+                    var val = $e.val();
+                    if (val !== '') {
+                        // Call the checker with the value
+                        // Also provide a callback to the _addError function setting its this
+                        $.fn[pluginName].checks[check]($e.val(), this._addError.bind(this), params);
+                    }
 
                     // Update tooltip with new errors
                     this._updateTooltip();


### PR DESCRIPTION
Extend plugin with two new built-in checks:
- `range` to check if input is a number between a min and/or max limit
- `length` to check that the length of the input is between a min and/or max limit

Also edited plug-in to allow checks to receive parameters, and makes built-in check return a status of their checks.
